### PR TITLE
Fixes #20531 - Fix typo in upload message

### DIFF
--- a/src/yum-plugins/enabled_repos_upload.py
+++ b/src/yum-plugins/enabled_repos_upload.py
@@ -164,7 +164,7 @@ class EnabledReport(object):
         return str(self.content)
 
 def close_hook(conduit):
-    conduit.info(2, "Uploading Enabled Reposistories Report")
+    conduit.info(2, "Uploading Enabled Repositories Report")
     try:
         upload_enabled_repos_report()
     except:


### PR DESCRIPTION
Correctly spelled repositories in output message.  Fixes http://projects.theforeman.org/issues/20531